### PR TITLE
Add PettingZoo-based RL environment

### DIFF
--- a/orc_dwarf_rl/README.md
+++ b/orc_dwarf_rl/README.md
@@ -1,0 +1,16 @@
+# Orc-Dwarf Reinforcement Learning
+
+This folder contains a simplified multi-agent RL setup using [PettingZoo](https://pettingzoo.farama.org/) and `sb3_contrib`.
+
+## Installation
+```bash
+pip install -r requirements.txt
+```
+
+## Training
+Run `python -m orc_dwarf_rl.main` to train agents in the environment. The script will save a model named `orc_dwarf_model`.
+
+## Evaluation
+After training, the script automatically runs a short evaluation showing a simple ASCII rendering of the grid.
+
+You can also call `orc_dwarf_rl.main.evaluate("orc_dwarf_model", episodes=3)` in Python to evaluate separately.

--- a/orc_dwarf_rl/agent.py
+++ b/orc_dwarf_rl/agent.py
@@ -1,0 +1,23 @@
+import numpy as np
+from typing import Optional
+
+
+class RLAgent:
+    """Wrapper around a trained RL policy."""
+
+    def __init__(self, model):
+        self.model = model
+
+    def act(self, observation: np.ndarray) -> int:
+        """Return action from the underlying policy."""
+        action, _ = self.model.predict(observation, deterministic=True)
+        return int(action)
+
+    @classmethod
+    def load(cls, path: str):
+        from stable_baselines3.common.base_class import BaseAlgorithm
+        model: BaseAlgorithm = BaseAlgorithm.load(path)
+        return cls(model)
+
+    def save(self, path: str):
+        self.model.save(path)

--- a/orc_dwarf_rl/config.py
+++ b/orc_dwarf_rl/config.py
@@ -1,0 +1,27 @@
+# Configuration for Orc-Dwarf RL environment
+
+# Map dimensions
+GRID_SIZE = 10
+
+# Agent counts
+NUM_ORCS = 5
+NUM_DWARFS = 5
+
+# Agent attributes
+MAX_ENERGY = 20
+INITIAL_ENERGY = 10
+DEFAULT_SIGHT = 5
+DEFAULT_SPEED = 1
+ATTACK_RANGE = 1
+
+# Resources
+RESOURCE_NODE_COUNT = 5
+RESOURCE_ENERGY = 5
+
+# Episode settings
+MAX_STEPS = 500
+
+# Reinforcement learning hyperparameters
+LEARNING_RATE = 3e-4
+GAMMA = 0.99
+BATCH_SIZE = 64

--- a/orc_dwarf_rl/main.py
+++ b/orc_dwarf_rl/main.py
@@ -1,0 +1,45 @@
+from sb3_contrib import MaskablePPO
+import supersuit as ss
+from .orc_dwarf_env import OrcDwarfEnv
+from .config import LEARNING_RATE, NUM_ORCS, NUM_DWARFS
+
+
+def train(total_timesteps=200000):
+    env = OrcDwarfEnv(num_orcs=NUM_ORCS, num_dwarfs=NUM_DWARFS)
+    env = ss.pad_observations_v0(env)
+    env = ss.pad_action_space_v0(env)
+    model = MaskablePPO(
+        policy="MlpPolicy",
+        env=env,
+        learning_rate=LEARNING_RATE,
+        verbose=1,
+    )
+    model.learn(total_timesteps=total_timesteps)
+    model.save("orc_dwarf_model")
+    return model
+
+
+def evaluate(model_path="orc_dwarf_model", episodes=5):
+    model = MaskablePPO.load(model_path)
+    env = OrcDwarfEnv()
+    env = ss.pad_observations_v0(env)
+    env = ss.pad_action_space_v0(env)
+    for ep in range(episodes):
+        observations = env.reset()
+        terminated = {a: False for a in env.agents}
+        truncated = {a: False for a in env.agents}
+        while env.agents:
+            actions = {a: model.predict(observations[a], deterministic=True)[0] for a in env.agents}
+            observations, rewards, terminations, truncations, infos = env.step(actions)
+            terminated.update(terminations)
+            truncated.update(truncations)
+            env.render()
+            if all(terminated.get(a, False) or truncated.get(a, False) for a in terminated):
+                break
+        print(f"Episode {ep+1} finished")
+    env.close()
+
+
+if __name__ == "__main__":
+    model = train()
+    evaluate()

--- a/orc_dwarf_rl/orc_dwarf_env.py
+++ b/orc_dwarf_rl/orc_dwarf_env.py
@@ -1,0 +1,224 @@
+import random
+import numpy as np
+from pettingzoo.utils import parallel_base_env
+from gymnasium import spaces
+
+from .config import (
+    GRID_SIZE,
+    NUM_ORCS,
+    NUM_DWARFS,
+    MAX_ENERGY,
+    INITIAL_ENERGY,
+    DEFAULT_SIGHT,
+    DEFAULT_SPEED,
+    ATTACK_RANGE,
+    RESOURCE_NODE_COUNT,
+    RESOURCE_ENERGY,
+    MAX_STEPS,
+)
+
+
+class OrcDwarfEnv(parallel_base_env.ParallelEnv):
+    """Simple grid-based predator/prey environment using PettingZoo's parallel API."""
+
+    metadata = {"name": "orc_dwarf_v0"}
+
+    def __init__(self, num_orcs=NUM_ORCS, num_dwarfs=NUM_DWARFS):
+        super().__init__()
+        self.num_orcs = num_orcs
+        self.num_dwarfs = num_dwarfs
+        self.grid_size = GRID_SIZE
+        self.pos = {}
+        self.energy = {}
+        self.alive = {}
+        self.steps = 0
+        self.resource_nodes = []
+
+        self.agents = [f"orc_{i}" for i in range(self.num_orcs)] + [
+            f"dwarf_{i}" for i in range(self.num_dwarfs)
+        ]
+        # spaces
+        obs_dim = 9  # [x,y,energy,res_x,res_y,enemy_x,enemy_y,sight,speed]
+        self.observation_spaces = {a: spaces.Box(low=-1.0, high=1.0, shape=(obs_dim,), dtype=np.float32) for a in self.agents}
+        self.action_spaces = {a: spaces.Discrete(9) for a in self.agents}
+
+    # ------------------------------------------------------------------
+    def _random_pos(self):
+        return (random.randrange(self.grid_size), random.randrange(self.grid_size))
+
+    def _spawn_resources(self):
+        self.resource_nodes = [self._random_pos() for _ in range(RESOURCE_NODE_COUNT)]
+
+    # ------------------------------------------------------------------
+    def reset(self, seed=None, options=None):
+        if seed is not None:
+            random.seed(seed)
+            np.random.seed(seed)
+        self.steps = 0
+        self._spawn_resources()
+        self.pos = {a: self._random_pos() for a in self.agents}
+        self.energy = {a: INITIAL_ENERGY for a in self.agents}
+        self.alive = {a: True for a in self.agents}
+        observations = {a: self.observe(a) for a in self.agents}
+        return observations
+
+    # ------------------------------------------------------------------
+    def step(self, actions):
+        rewards = {a: 0.0 for a in self.agents}
+        terminations = {a: False for a in self.agents}
+        truncations = {a: False for a in self.agents}
+        infos = {a: {} for a in self.agents}
+        self.steps += 1
+
+        # movement
+        for agent, action in actions.items():
+            if not self.alive.get(agent, False):
+                continue
+            x, y = self.pos[agent]
+            dx, dy = 0, 0
+            # direct moves
+            if action == 0:
+                dy = -DEFAULT_SPEED
+            elif action == 1:
+                dy = DEFAULT_SPEED
+            elif action == 2:
+                dx = DEFAULT_SPEED
+            elif action == 3:
+                dx = -DEFAULT_SPEED
+            elif action == 5:  # toward resource
+                target = self._nearest_resource(x, y)
+                if target:
+                    dx, dy = self._direction_toward((x, y), target)
+            elif action == 6:  # toward enemy
+                target = self._nearest_enemy(agent)
+                if target:
+                    dx, dy = self._direction_toward((x, y), self.pos[target])
+            elif action == 7:  # flee enemy
+                target = self._nearest_enemy(agent)
+                if target:
+                    dx, dy = self._direction_away((x, y), self.pos[target])
+            # action 4 = stay still
+            self.pos[agent] = self._clamp_pos(x + dx, y + dy)
+
+        # attacks after movement
+        for agent, action in actions.items():
+            if not self.alive.get(agent, False):
+                continue
+            if action == 8:
+                enemy = self._nearest_enemy(agent)
+                if enemy and self._manhattan(self.pos[agent], self.pos[enemy]) <= ATTACK_RANGE:
+                    self.alive[enemy] = False
+                    rewards[agent] += 2.0
+                    rewards[enemy] -= 2.0
+
+        # resource collection and energy updates
+        for agent in list(self.agents):
+            if not self.alive.get(agent, False):
+                continue
+            # living bonus
+            rewards[agent] += 0.01
+            self.energy[agent] -= 1
+            x, y = self.pos[agent]
+            if (x, y) in self.resource_nodes:
+                rewards[agent] += 1.0
+                self.energy[agent] = min(MAX_ENERGY, self.energy[agent] + RESOURCE_ENERGY)
+                self.resource_nodes.remove((x, y))
+                self.resource_nodes.append(self._random_pos())
+            if self.energy[agent] <= 0 or not self.alive[agent]:
+                terminations[agent] = True
+                self.alive[agent] = False
+                rewards[agent] -= 5.0
+
+        if self.steps >= MAX_STEPS:
+            for agent in self.agents:
+                if not terminations[agent]:
+                    truncations[agent] = True
+
+        # remove dead agents from list
+        for agent in self.agents:
+            if terminations[agent] or truncations[agent]:
+                pass
+        self.agents = [a for a in self.agents if self.alive.get(a, False)]
+        observations = {a: self.observe(a) for a in self.agents}
+        return observations, rewards, terminations, truncations, infos
+
+    # ------------------------------------------------------------------
+    def _direction_toward(self, pos, target):
+        x, y = pos
+        tx, ty = target
+        dx = 1 if tx > x else -1 if tx < x else 0
+        dy = 1 if ty > y else -1 if ty < y else 0
+        return dx, dy
+
+    def _direction_away(self, pos, target):
+        dx, dy = self._direction_toward(pos, target)
+        return -dx, -dy
+
+    def _clamp_pos(self, x, y):
+        x = max(0, min(self.grid_size - 1, int(x)))
+        y = max(0, min(self.grid_size - 1, int(y)))
+        return (x, y)
+
+    def _manhattan(self, p1, p2):
+        return abs(p1[0] - p2[0]) + abs(p1[1] - p2[1])
+
+    def _nearest_resource(self, x, y):
+        if not self.resource_nodes:
+            return None
+        return min(self.resource_nodes, key=lambda p: self._manhattan((x, y), p))
+
+    def _nearest_enemy(self, agent):
+        species = "orc" if agent.startswith("dwarf") else "dwarf"
+        enemies = [a for a in self.agents if a.startswith(species) and self.alive.get(a, False)]
+        if not enemies:
+            return None
+        x, y = self.pos[agent]
+        return min(enemies, key=lambda e: self._manhattan((x, y), self.pos[e]))
+
+    # ------------------------------------------------------------------
+    def observe(self, agent):
+        x, y = self.pos[agent]
+        norm_x = x / (self.grid_size - 1)
+        norm_y = y / (self.grid_size - 1)
+        energy = self.energy[agent] / MAX_ENERGY
+
+        res = self._nearest_resource(x, y)
+        if res:
+            res_dx = (res[0] - x) / self.grid_size
+            res_dy = (res[1] - y) / self.grid_size
+        else:
+            res_dx = res_dy = 0.0
+
+        enemy = self._nearest_enemy(agent)
+        if enemy:
+            ex, ey = self.pos[enemy]
+            enemy_dx = (ex - x) / self.grid_size
+            enemy_dy = (ey - y) / self.grid_size
+        else:
+            enemy_dx = enemy_dy = 0.0
+
+        sight = DEFAULT_SIGHT / self.grid_size
+        speed = DEFAULT_SPEED
+        obs = np.array([
+            norm_x,
+            norm_y,
+            energy,
+            res_dx,
+            res_dy,
+            enemy_dx,
+            enemy_dy,
+            sight,
+            speed,
+        ], dtype=np.float32)
+        return obs
+
+    # ------------------------------------------------------------------
+    def render(self):
+        grid = [["." for _ in range(self.grid_size)] for _ in range(self.grid_size)]
+        for rx, ry in self.resource_nodes:
+            grid[ry][rx] = "R"
+        for a in self.agents:
+            x, y = self.pos[a]
+            grid[y][x] = "O" if a.startswith("orc") else "D"
+        print("\n".join("".join(row) for row in grid))
+        print()

--- a/orc_dwarf_rl/requirements.txt
+++ b/orc_dwarf_rl/requirements.txt
@@ -1,0 +1,6 @@
+pettingzoo
+supersuit
+sb3_contrib
+stable-baselines3
+gymnasium
+torch


### PR DESCRIPTION
## Summary
- set up `orc_dwarf_rl` package for MARL experiments
- implement `OrcDwarfEnv` parallel PettingZoo environment
- add simple RL agent wrapper and training script
- provide configuration, requirements and README instructions

## Testing
- `python -m py_compile orc_dwarf_rl/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683f52261c6c8324a175ab23cba11cd3