### PR TITLE
Fix RL module imports

### DIFF
--- a/orc_dwarf_rl/main.py
+++ b/orc_dwarf_rl/main.py
@@ -1,7 +1,10 @@
 from sb3_contrib import MaskablePPO
 import supersuit as ss
-from .orc_dwarf_env import OrcDwarfEnv
-from .config import LEARNING_RATE, NUM_ORCS, NUM_DWARFS
+
+# Absolute imports allow running this script directly with ``python main.py``
+# while still functioning when used as a module via ``python -m orc_dwarf_rl.main``.
+from orc_dwarf_rl.orc_dwarf_env import OrcDwarfEnv
+from orc_dwarf_rl.config import LEARNING_RATE, NUM_ORCS, NUM_DWARFS
 
 
 def train(total_timesteps=200000):

--- a/orc_dwarf_rl/orc_dwarf_env.py
+++ b/orc_dwarf_rl/orc_dwarf_env.py
@@ -3,7 +3,11 @@ import numpy as np
 from pettingzoo.utils import parallel_base_env
 from gymnasium import spaces
 
-from .config import (
+# When run as a script the relative imports below fail because Python does not
+# treat the file as part of the ``orc_dwarf_rl`` package.  Using absolute
+# imports works both when the module is executed directly and when it is
+# imported as part of the package.
+from orc_dwarf_rl.config import (
     GRID_SIZE,
     NUM_ORCS,
     NUM_DWARFS,


### PR DESCRIPTION
## Summary
- fix imports so RL scripts can be run directly

## Testing
- `python -m py_compile orc_dwarf_rl/orc_dwarf_env.py orc_dwarf_rl/main.py`
- `python orc_dwarf_rl/orc_dwarf_env.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python orc_dwarf_rl/main.py --help` *(fails: No module named 'sb3_contrib')*

------
https://chatgpt.com/codex/tasks/task_e_683f55d2f950832495956f9d8406983b