### PR TITLE
Fix env compatibility with supersuit

### DIFF
--- a/orc_dwarf_rl/README.md
+++ b/orc_dwarf_rl/README.md
@@ -1,6 +1,10 @@
 # Orc-Dwarf Reinforcement Learning
 
 This folder contains a simplified multi-agent RL setup using [PettingZoo](https://pettingzoo.farama.org/) and `sb3_contrib`.
+The environment is built on top of PettingZoo's `ParallelEnv` API.  Older
+releases of this repository relied on the deprecated `parallel_base_env`
+interface, so make sure you have an up to date copy of the code if you see
+import errors regarding `parallel_base_env`.
 
 ## Installation
 ```bash

--- a/orc_dwarf_rl/orc_dwarf_env.py
+++ b/orc_dwarf_rl/orc_dwarf_env.py
@@ -48,6 +48,13 @@ class OrcDwarfEnv(ParallelEnv):
         self.agents = [f"orc_{i}" for i in range(self.num_orcs)] + [
             f"dwarf_{i}" for i in range(self.num_dwarfs)
         ]
+        # ``possible_agents`` is a static list of all agents that can appear in
+        # the environment.  ``supersuit`` relies on this attribute for padding
+        # wrappers such as ``pad_observations_v0`` and ``pad_action_space_v0``.
+        # PettingZoo's API expects this list to remain constant across resets,
+        # so we store it separately from ``self.agents`` which is pruned as
+        # agents die during an episode.
+        self.possible_agents = list(self.agents)
         # spaces
         obs_dim = 9  # [x,y,energy,res_x,res_y,enemy_x,enemy_y,sight,speed]
         self.observation_spaces = {a: spaces.Box(low=-1.0, high=1.0, shape=(obs_dim,), dtype=np.float32) for a in self.agents}
@@ -66,6 +73,8 @@ class OrcDwarfEnv(ParallelEnv):
             random.seed(seed)
             np.random.seed(seed)
         self.steps = 0
+        # Ensure all agents are present at the start of each episode.
+        self.agents = list(self.possible_agents)
         self._spawn_resources()
         self.pos = {a: self._random_pos() for a in self.agents}
         self.energy = {a: INITIAL_ENERGY for a in self.agents}


### PR DESCRIPTION
## Summary
- add `possible_agents` attribute to environment
- reset env to full agent list each episode
- clarify PettingZoo dependency in README

## Testing
- `python -m orc_dwarf_rl.main` *(fails: No module named 'sb3_contrib')*
- `python -m orc_dwarf_rl.orc_dwarf_env` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683f589f69c083248e402ee9425ee092